### PR TITLE
Add inverted mode to bad list test and add related unit tests

### DIFF
--- a/Easy-Password-Validator-GUI/Easy-Password-Validator-GUI.csproj
+++ b/Easy-Password-Validator-GUI/Easy-Password-Validator-GUI.csproj
@@ -13,9 +13,9 @@
 		<Company>NF Software Inc.</Company>
 		<Product>Easy Password Validator</Product>
 		<Copyright>Copyright 2024 $(Company)</Copyright>
-		<AssemblyVersion>1.2.9.0</AssemblyVersion>
-		<FileVersion>1.2.9.0</FileVersion>
-		<Version>1.2.9</Version>
+		<AssemblyVersion>1.2.10.0</AssemblyVersion>
+		<FileVersion>1.2.10.0</FileVersion>
+		<Version>1.2.10</Version>
 		<MauiVersion>9.0.81</MauiVersion>
 
 		<!-- Display name -->
@@ -26,8 +26,8 @@
 		<ApplicationIdGuid>6F9296F4-8B2E-4C2B-883E-EF6C933AE2F6</ApplicationIdGuid>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.2.9</ApplicationDisplayVersion>
-		<ApplicationVersion>2</ApplicationVersion>
+		<ApplicationDisplayVersion>1.2.10</ApplicationDisplayVersion>
+		<ApplicationVersion>3</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>

--- a/Easy-Password-Validator-GUI/Platforms/Windows/Package.appxmanifest
+++ b/Easy-Password-Validator-GUI/Platforms/Windows/Package.appxmanifest
@@ -6,7 +6,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=NF Software Inc" Version="1.2.9.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=NF Software Inc" Version="1.2.10.0" />
 
   <Properties>
     <DisplayName>$placeholder$</DisplayName>

--- a/Easy-Password-Validator-GUI/easy-password-validator-gui.appinstaller
+++ b/Easy-Password-Validator-GUI/easy-password-validator-gui.appinstaller
@@ -7,9 +7,9 @@
     <MainPackage
         Name="6F9296F4-8B2E-4C2B-883E-EF6C933AE2F6"
         Publisher="CN=NF Software Inc, O=NF Software Inc, L=New Hamburg, S=Ontario, C=CA, OID.1.3.6.1.4.1.311.60.2.1.2=Ontario, OID.1.3.6.1.4.1.311.60.2.1.3=CA, SERIALNUMBER=1000368489, OID.2.5.4.15=Private Organization"
-        Version="1.2.9.0"
+        Version="1.2.10.0"
         ProcessorArchitecture="x64"
-        Uri="https://github.com/NF-Software-Inc/Easy-Password-Validator/releases/download/1.2.9/Easy-Password-Validator-GUI_1.2.9.0_x64.msix" />
+        Uri="https://github.com/NF-Software-Inc/Easy-Password-Validator/releases/download/1.2.10/Easy-Password-Validator-GUI_1.2.10.0_x64.msix" />
 
     <UpdateSettings>
         <OnLaunch HoursBetweenUpdateChecks="3" ShowPrompt="false" />

--- a/Easy-Password-Validator-Test/Easy-Password-Validator-Test.csproj
+++ b/Easy-Password-Validator-Test/Easy-Password-Validator-Test.csproj
@@ -8,9 +8,9 @@
     <Company>NF Software Inc.</Company>
     <Product>Easy Password Validator Test</Product>
     <Copyright>Copyright 2024 $(Company)</Copyright>
-    <AssemblyVersion>1.2.9.0</AssemblyVersion>
-    <FileVersion>1.2.9.0</FileVersion>
-    <Version>1.2.9</Version>
+    <AssemblyVersion>1.2.10.0</AssemblyVersion>
+    <FileVersion>1.2.10.0</FileVersion>
+    <Version>1.2.10</Version>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/Easy-Password-Validator-Test/IndividualTests.cs
+++ b/Easy-Password-Validator-Test/IndividualTests.cs
@@ -57,7 +57,7 @@ public class IndividualTests
     {
         var requirements = new PasswordRequirements() { UseBadList = true };
         var badList = new[] { "", "john", "doe", "john.doe" };
-        var test = new TestBadList(requirements, badList) { ListType = BadListTypes.UserInformation };
+        var test = new TestBadList(requirements, badList) { UseInvertedMode = true };
         var result = test.TestAndScore(value);
 
         Assert.True(result);
@@ -71,7 +71,7 @@ public class IndividualTests
     {
         var requirements = new PasswordRequirements() { UseBadList = true };
         var badList = new[] { "john", "doe", "john.doe" };
-        var test = new TestBadList(requirements, badList) { ListType = BadListTypes.UserInformation };
+        var test = new TestBadList(requirements, badList) { UseInvertedMode = true };
         var result = test.TestAndScore(value);
 
         Assert.False(result, test.FailureMessage);

--- a/Easy-Password-Validator-Test/IndividualTests.cs
+++ b/Easy-Password-Validator-Test/IndividualTests.cs
@@ -56,7 +56,7 @@ public class IndividualTests
     public void CheckBadListUserInformationTrue(string value)
     {
         var requirements = new PasswordRequirements() { UseBadList = true };
-        var badList = new[] { "john", "doe", "john.doe" };
+        var badList = new[] { "", "john", "doe", "john.doe" };
         var test = new TestBadList(requirements, badList) { ListType = BadListTypes.UserInformation };
         var result = test.TestAndScore(value);
 

--- a/Easy-Password-Validator-Test/IndividualTests.cs
+++ b/Easy-Password-Validator-Test/IndividualTests.cs
@@ -50,6 +50,34 @@ public class IndividualTests
     }
 
     [Theory]
+    [InlineData("xyz123")]
+    [InlineData("Password1!")]
+    [InlineData("MySecurePass456")]
+    public void CheckBadListUserInformationTrue(string value)
+    {
+        var requirements = new PasswordRequirements() { UseBadList = true };
+        var badList = new[] { "john", "doe", "john.doe" };
+        var test = new TestBadList(requirements, badList) { ListType = BadListTypes.UserInformation };
+        var result = test.TestAndScore(value);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("john.doe.1")]
+    [InlineData("John.Doe.Password")]
+    [InlineData("xyz123john")]
+    public void CheckBadListUserInformationFalse(string value)
+    {
+        var requirements = new PasswordRequirements() { UseBadList = true };
+        var badList = new[] { "john", "doe", "john.doe" };
+        var test = new TestBadList(requirements, badList) { ListType = BadListTypes.UserInformation };
+        var result = test.TestAndScore(value);
+
+        Assert.False(result, test.FailureMessage);
+    }
+
+    [Theory]
     [InlineData("hasdigit1")]
     public void RequireDigitTrue(string value)
     {
@@ -113,7 +141,7 @@ public class IndividualTests
     [Theory]
     [InlineData("", 1)]
     [InlineData("Need6", 6)]
-    public void MinimumLengthFalse(string value, int minimum) 
+    public void MinimumLengthFalse(string value, int minimum)
     {
         var requirements = new PasswordRequirements() { UseLength = true, MinLength = minimum };
         var test = new TestLength(requirements);
@@ -197,7 +225,7 @@ public class IndividualTests
     [InlineData("")]
     [InlineData("nopunctuation")]
     [InlineData("nosymbol")]
-    public void RequirePunctuationFalse(string value) 
+    public void RequirePunctuationFalse(string value)
     {
         var requirements = new PasswordRequirements() { UsePunctuation = true, RequirePunctuation = true };
         var test = new TestPunctuation(requirements);
@@ -223,7 +251,7 @@ public class IndividualTests
     [InlineData("", 0)]
     [InlineData("Maaaax3", 3)]
     [InlineData("MMMaaaxxxx3", 3)]
-    public void MaximumRepeatFalse(string value, int maximum) 
+    public void MaximumRepeatFalse(string value, int maximum)
     {
         var requirements = new PasswordRequirements() { UseRepeat = true, MaxRepeatSameCharacter = maximum };
         var test = new TestRepeat(requirements);

--- a/Easy-Password-Validator-Test/PasswordValidatorTests.cs
+++ b/Easy-Password-Validator-Test/PasswordValidatorTests.cs
@@ -55,7 +55,7 @@ public class PasswordValidatorTests
     [InlineData("Nine.10!")]
     public void CheckPasswordWithRequirementsTrue(string value)
     {
-        var requirements = new PasswordRequirements() 
+        var requirements = new PasswordRequirements()
         {
             RequireDigit = true,
             RequireLowercase = true,
@@ -126,7 +126,7 @@ public class PasswordValidatorTests
     [InlineData("score low")]
     [InlineData("11111qwerty999888")]
     [InlineData("!_!")]
-    public void CheckPasswordScoreOnlyFalse(string value) 
+    public void CheckPasswordScoreOnlyFalse(string value)
     {
         var requirements = new PasswordRequirements()
         {
@@ -200,7 +200,7 @@ public class PasswordValidatorTests
     ];
 
     [Theory]
-    [InlineData("123 Fake St first.last")]
+    [InlineData("SecureP@ssw0rd!")]
     public void CheckPasswordWithUserDataTrue(string value)
     {
         var requirements = new PasswordRequirements();

--- a/Easy-Password-Validator-Test/PasswordValidatorTests.cs
+++ b/Easy-Password-Validator-Test/PasswordValidatorTests.cs
@@ -213,7 +213,8 @@ public class PasswordValidatorTests
     [Theory]
     [InlineData("123 fake st")]
     [InlineData("first.last")]
-    public void CheckPasswordWithUserDataFalse(string value)
+	[InlineData("123 Fake St first.last")]
+	public void CheckPasswordWithUserDataFalse(string value)
     {
         var requirements = new PasswordRequirements();
         var validator = new PasswordValidatorService(requirements);

--- a/Easy-Password-Validator/Easy-Password-Validator.csproj
+++ b/Easy-Password-Validator/Easy-Password-Validator.csproj
@@ -6,9 +6,9 @@
 		<Company>NF Software Inc.</Company>
 		<Authors>NF Software Inc.</Authors>
 		<Copyright>Copyright 2023 $(Company)</Copyright>
-		<Version>1.2.9</Version>
-		<AssemblyVersion>1.2.9.0</AssemblyVersion>
-		<FileVersion>1.2.9.0</FileVersion>
+		<Version>1.2.10</Version>
+		<AssemblyVersion>1.2.10.0</AssemblyVersion>
+		<FileVersion>1.2.10.0</FileVersion>
 		<PackageId>Easy.Password.Validator</PackageId>
 		<PackageTags>password validation validator check strength checker utility entropy</PackageTags>
 		<RepositoryUrl>https://github.com/NF-Software-Inc/Easy-Password-Validator</RepositoryUrl>
@@ -18,6 +18,7 @@
 			There are two parts to this library: score checking and validation testing. Testing a password will perform both actions. The score checking will provide an overall score to a password which is the sum of all test scores. The validation testing will return whether a password passed or failed the tests.
 		</Description>
 		<PackageReleaseNotes>
+			1.2.10 Add inverted mode to bad list test
 			1.2.9 Add Arabic translation for error messages
 			1.2.6 Add Dutch translation for error messages
 			1.2.5 Add Chinese translation for error messages

--- a/Easy-Password-Validator/PasswordValidatorService.cs
+++ b/Easy-Password-Validator/PasswordValidatorService.cs
@@ -94,11 +94,39 @@ namespace Easy_Password_Validator
 		/// Runs scoring and validation on the specified password
 		/// </summary>
 		/// <param name="password">The password to test</param>
+		/// <exception cref="ArgumentNullException"></exception>
+		/// <exception cref="ArgumentException"></exception>
+		public bool TestAndScore(string password) => TestAndScore(password, null, null, false);
+
+		/// <summary>
+		/// Runs scoring and validation on the specified password
+		/// </summary>
+		/// <param name="password">The password to test</param>
+		/// <param name="userInformation">An optional list containing user information to compare against the password</param>
+		/// <exception cref="ArgumentNullException"></exception>
+		/// <exception cref="ArgumentException"></exception>
+		public bool TestAndScore(string password, IEnumerable<string> userInformation) => TestAndScore(password, userInformation, null, true);
+
+		/// <summary>
+		/// Runs scoring and validation on the specified password
+		/// </summary>
+		/// <param name="password">The password to test</param>
 		/// <param name="userInformation">An optional list containing user information to compare against the password</param>
 		/// <param name="languageCode">An optional language code used for error text</param>
 		/// <exception cref="ArgumentException"></exception>
 		/// <exception cref="ArgumentNullException"></exception>
-		public bool TestAndScore(string password, IEnumerable<string> userInformation = null, string languageCode = null)
+		public bool TestAndScore(string password, IEnumerable<string> userInformation, string languageCode) => TestAndScore(password, userInformation, languageCode, true);
+
+		/// <summary>
+		/// Runs scoring and validation on the specified password
+		/// </summary>
+		/// <param name="password">The password to test</param>
+		/// <param name="userInformation">An optional list containing user information to compare against the password</param>
+		/// <param name="languageCode">An optional language code used for error text</param>
+		/// <param name="useInvertedMode">Indicates whether to use <see cref="TestBadList.UseInvertedMode"/> for user information bad list tests</param>
+		/// <exception cref="ArgumentNullException"></exception>
+		/// <exception cref="ArgumentException"></exception>
+		public bool TestAndScore(string password, IEnumerable<string> userInformation, string languageCode, bool useInvertedMode)
 		{
 			// Input validation
 			if (string.IsNullOrEmpty(password))
@@ -136,10 +164,17 @@ namespace Easy_Password_Validator
 				if (existing != null)
 				{
 					existing.BadList = userInformation;
-					existing.UseInvertedMode = true;
+					existing.UseInvertedMode = useInvertedMode;
 				}
 				else
-					BadListTests.Add(new TestBadList(Settings, userInformation) { ListType = BadListTypes.UserInformation, TestL33tVariants = true, UseInvertedMode = true });
+				{
+					BadListTests.Add(new TestBadList(Settings, userInformation)
+					{
+						ListType = BadListTypes.UserInformation,
+						TestL33tVariants = true,
+						UseInvertedMode = useInvertedMode
+					});
+				}
 			}
 
 			RunBadListTests(password, false);
@@ -415,8 +450,8 @@ namespace Easy_Password_Validator
 					case "ro":
 					case "pl":
 					case "zh":
-                    case "ar":
-                        return true;
+					case "ar":
+						return true;
 					default:
 						return false;
 				};

--- a/Easy-Password-Validator/PasswordValidatorService.cs
+++ b/Easy-Password-Validator/PasswordValidatorService.cs
@@ -134,9 +134,12 @@ namespace Easy_Password_Validator
 				var existing = BadListTests.FirstOrDefault(x => x.ListType == BadListTypes.UserInformation);
 
 				if (existing != null)
+				{
 					existing.BadList = userInformation;
+					existing.UseInvertedMode = true;
+				}
 				else
-					BadListTests.Add(new TestBadList(Settings, userInformation) { ListType = BadListTypes.UserInformation, TestL33tVariants = true });
+					BadListTests.Add(new TestBadList(Settings, userInformation) { ListType = BadListTypes.UserInformation, TestL33tVariants = true, UseInvertedMode = true });
 			}
 
 			RunBadListTests(password, false);

--- a/Easy-Password-Validator/Tests/TestBadList.cs
+++ b/Easy-Password-Validator/Tests/TestBadList.cs
@@ -112,8 +112,8 @@ namespace Easy_Password_Validator.Tests
 
             // Check for match
             var match = UseInvertedMode
-                ? BadList.Any(x => x.Length > 0 && password.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0)    // Inverted mode: password contains bad list item
-                : BadList.Any(x => x.Length > 0 && x.IndexOf(password, StringComparison.OrdinalIgnoreCase) >= 0);   // Normal mode: bad list item contains password
+                ? BadList.Any(x => x.Length > 0 && password.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0)
+                : BadList.Any(x => x.Length > 0 && x.IndexOf(password, StringComparison.OrdinalIgnoreCase) >= 0);
 
             // Adjust score
             ScoreModifier = match ? -50 : 0;

--- a/Easy-Password-Validator/Tests/TestBadList.cs
+++ b/Easy-Password-Validator/Tests/TestBadList.cs
@@ -94,6 +94,11 @@ namespace Easy_Password_Validator.Tests
         /// </summary>
         public bool TestL33tVariants { get; set; }
 
+        /// <summary>
+        /// Specifies whether to use inverted mode (password contains bad list item) instead of normal mode (bad list item contains password)
+        /// </summary>
+        public bool UseInvertedMode { get; set; }
+
         /// <inheritdoc/>
         public bool TestAndScore(string password)
         {
@@ -106,11 +111,9 @@ namespace Easy_Password_Validator.Tests
                 return true;
 
             // Check for match
-            // 1. badList item contains password
-            var match = BadList.Any(x => !string.IsNullOrWhiteSpace(x) && x.IndexOf(password, StringComparison.OrdinalIgnoreCase) >= 0);
-            // 2. password contains badList item
-            if (!match && ListType == BadListTypes.UserInformation)
-                match = BadList.Any(x => !string.IsNullOrWhiteSpace(x) && password.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0);
+            var match = UseInvertedMode
+                ? BadList.Any(x => x.Length > 0 && password.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0)    // Inverted mode: password contains bad list item
+                : BadList.Any(x => x.Length > 0 && x.IndexOf(password, StringComparison.OrdinalIgnoreCase) >= 0);   // Normal mode: bad list item contains password
 
             // Adjust score
             ScoreModifier = match ? -50 : 0;

--- a/Easy-Password-Validator/Tests/TestBadList.cs
+++ b/Easy-Password-Validator/Tests/TestBadList.cs
@@ -107,10 +107,10 @@ namespace Easy_Password_Validator.Tests
 
             // Check for match
             // 1. badList item contains password
-            var match = BadList.Any(x => x.IndexOf(password, StringComparison.OrdinalIgnoreCase) >= 0);
+            var match = BadList.Any(x => !string.IsNullOrWhiteSpace(x) && x.IndexOf(password, StringComparison.OrdinalIgnoreCase) >= 0);
             // 2. password contains badList item
-            if (match == false && ListType == BadListTypes.UserInformation)
-                match = BadList.Any(x => password.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0);
+            if (!match && ListType == BadListTypes.UserInformation)
+                match = BadList.Any(x => !string.IsNullOrWhiteSpace(x) && password.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0);
 
             // Adjust score
             ScoreModifier = match ? -50 : 0;

--- a/Easy-Password-Validator/Tests/TestBadList.cs
+++ b/Easy-Password-Validator/Tests/TestBadList.cs
@@ -106,7 +106,11 @@ namespace Easy_Password_Validator.Tests
                 return true;
 
             // Check for match
+            // 1. badList item contains password
             var match = BadList.Any(x => x.IndexOf(password, StringComparison.OrdinalIgnoreCase) >= 0);
+            // 2. password contains badList item
+            if (match == false && ListType == BadListTypes.UserInformation)
+                match = BadList.Any(x => password.IndexOf(x, StringComparison.OrdinalIgnoreCase) >= 0);
 
             // Adjust score
             ScoreModifier = match ? -50 : 0;


### PR DESCRIPTION
Enhanced bad list matching to check both directions for user information and added corresponding unit tests.
Issue reference: https://github.com/NF-Software-Inc/Easy-Password-Validator/issues/19